### PR TITLE
Added restore on open and port forwarding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,10 +15,10 @@
 	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+	"forwardPorts": [5000],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
+	"postCreateCommand": "dotnet workload restore ./DAPM/DAPM.AppHost/DAPM.AppHost.csproj && dotnet restore ./DAPM/DAPM.sln",
 
 	// Configure tool-specific properties.
 	"customizations": {


### PR DESCRIPTION
Restore workload for Aspire and restore packages. So now you can run `dotnet build DAPM/DAPM.sln` from root folder.
Add port forwarding for port 5000 where the api is located.
You can run `docker-compose up --build` and then go to http://localhost:5000/swagger/index.html
#12 
![image](https://github.com/user-attachments/assets/8e24b797-b20d-472c-a5ec-46d66a95f850)
