### PR TITLE
Add 5001 to port forward in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [5000],
+	"forwardPorts": [5000, 5001],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "dotnet workload restore ./DAPM/DAPM.AppHost/DAPM.AppHost.csproj && dotnet restore ./DAPM/DAPM.sln",


### PR DESCRIPTION
Added port `5001` in dev container such that the peer api port is also exposed.

Closes #24 